### PR TITLE
Fix array imports and length imports

### DIFF
--- a/src/array/index.js
+++ b/src/array/index.js
@@ -1,0 +1,6 @@
+import filter from 'array/filter'
+import map from 'array/map'
+import reduce from 'array/reduce'
+import reduceRight from 'array/reduceRight'
+
+export { filter, map, reduce, reduceRight }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,10 +5,12 @@ const path = require('path')
 module.exports = {
   context: path.resolve(__dirname, './src'),
   entry: {
+    array: './array/index.js',
     'array/filter': './array/filter/index.js',
     'array/map': './array/map/index.js',
     'array/reduce': './array/reduce/index.js',
     'array/reduceRight': './array/reduce/index.js',
+    length: './length/index.js',
     combine: './combine/index.js',
     compose: './compose/index.js',
     'compose/map': './compose/map.js',


### PR DESCRIPTION
So we can use the syntax
```
import {map, reduce, filter} from 'oncha/array'
```

Also length was missing from the built package.